### PR TITLE
fix: set uid for each item in Alfred response

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -51,6 +51,7 @@ class AlfredOutputItem:
     arg: str | list[str] | None = None
     icon: AlfredOutputItemIcon | None = None
     variables: dict[str, Any] | None = None
+    uid: str | None = None
 
     def __post_init__(self):
         # Automatically fetch an icon based on the title if no icon is provided

--- a/src/totp_accounts_manager.py
+++ b/src/totp_accounts_manager.py
@@ -12,7 +12,12 @@ from src.models import (
     TotpAccount,
     TotpAccounts,
 )
-from src.utils import calculate_time_remaining, sanitize_service_name, str_to_bool
+from src.utils import (
+    calculate_time_remaining,
+    create_uuid_from_string,
+    sanitize_service_name,
+    str_to_bool,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -104,6 +109,7 @@ def format_totp_result(accounts: TotpAccounts) -> AlfredOutput:
                     arg=current_totp,
                     match=service_name,
                     icon=AlfredOutputItemIcon.from_service(sanitized_service_name),
+                    uid=create_uuid_from_string(service_name + service_data.username),
                 )
             )
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,3 +1,5 @@
+import hashlib
+import uuid
 from datetime import datetime
 
 from src.models import AlfredOutput, AlfredOutputItem, TotpAccounts
@@ -69,3 +71,8 @@ def output_alfred_message(title: str, subtitle: str, variables: dict | None = No
     AlfredOutput(
         [AlfredOutputItem(title=title, subtitle=subtitle, variables=variables)]
     ).print_json()
+
+
+def create_uuid_from_string(val: str) -> str:
+    hex_string = hashlib.md5(val.encode("UTF-8")).hexdigest()
+    return str(uuid.UUID(hex=hex_string))


### PR DESCRIPTION
Setting the `uid` for each item allows Alfred to uniquely identify each item. This fixes a bug where, upon every re-run of the script filter (which happens every 1s per e05c79b8c6687ec3803da79cce3f665e3dc8819a), Alfred would throw focus back to the top of the list if the user had scrolled down.

See https://www.alfredapp.com/help/workflows/inputs/script-filter/json#ordering