### PR TITLE
Fix bugs around validation and usage of the defined Ente CLI path

### DIFF
--- a/src/ente_auth.py
+++ b/src/ente_auth.py
@@ -12,7 +12,7 @@ class EnteAuth:
             if self.check_ente_binary(ente_auth_binary_path_env):
                 self.ente_auth_binary_path = ente_auth_binary_path_env
             else:
-                raise OSError(f"Ente binary was not found at {ente_auth_binary_path_env} or is not executable. Please check the path is correct.")
+                raise OSError(f"Ente binary was not found at '{ente_auth_binary_path_env}' or is not executable. Please check the path is correct.")
         else:
             self.ente_auth_binary_path = self._find_ente_path()
 

--- a/src/ente_auth.py
+++ b/src/ente_auth.py
@@ -48,7 +48,7 @@ class EnteAuth:
         logger.debug("Ente auth export file not found. Exporting...")
         try:
             result = subprocess.run(
-                ["ente", "export"],
+                [self.ente_auth_binary_path, "export"],
                 check=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,

--- a/src/ente_auth.py
+++ b/src/ente_auth.py
@@ -9,9 +9,10 @@ class EnteAuth:
     def __init__(self):
         ente_auth_binary_path_env = os.getenv("ENTE_AUTH_BINARY_PATH")
         if ente_auth_binary_path_env:
-            self.ente_auth_binary_path = self.check_ente_binary(
-                ente_auth_binary_path_env
-            )
+            if self.check_ente_binary(ente_auth_binary_path_env):
+                self.ente_auth_binary_path = ente_auth_binary_path_env
+            else:
+                raise OSError(f"Ente binary was not found at {ente_auth_binary_path_env} or is not executable. Please check the path is correct.")
         else:
             self.ente_auth_binary_path = self._find_ente_path()
 


### PR DESCRIPTION
* If `ENTE_AUTH_BINARY_PATH` is defined, the script would set `self.ente_auth_binary_path` to the boolean response of `EnteAuth.check_ente_binary()`, as opposed to using the function's response as a condition and then setting `self.ente_auth_binary_path` to the value of `ENTE_AUTH_BINARY_PATH` upon successful validation.
* `EnteAuth.export_ente_auth_accounts()` was not using the defined path, whether passed by the user or discovered by the script.