### PR TITLE
fix: define `PYTHONPATH` in script filters

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -279,7 +279,8 @@
 				<key>runningsubtext</key>
 				<string>Getting TOTP accounts...</string>
 				<key>script</key>
-				<string>python3 main.py get_accounts</string>
+				<string>export PYTHONPATH='.venv/lib/python3.12/site-packages'
+python3 main.py get_accounts</string>
 				<key>scriptargtype</key>
 				<integer>0</integer>
 				<key>scriptfile</key>
@@ -387,7 +388,8 @@
 				<key>runningsubtext</key>
 				<string>Importing TOTP accounts and downloading icons....</string>
 				<key>script</key>
-				<string>python3 main.py import</string>
+				<string>export PYTHONPATH='.venv/lib/python3.12/site-packages'
+python3 main.py import</string>
 				<key>scriptargtype</key>
 				<integer>1</integer>
 				<key>scriptfile</key>
@@ -703,11 +705,6 @@ ente version
 			<string>OVERWRITE_EXPORT</string>
 		</dict>
 	</array>
-	<key>variables</key>
-	<dict>
-		<key>PYTHONPATH</key>
-		<string>.venv/lib/python3.12/site-packages</string>
-	</dict>
 	<key>version</key>
 	<string>2.2.3</string>
 	<key>webaddress</key>


### PR DESCRIPTION
This moves the `PYTHONPATH` definition from a single workflow environment variable to a line in each script filter.

It's not as nice of a solution, but it avoids the issue where env var values are retained from the previous version when a user updates the workflow.

That functionality is optional but is enabled by default and will realistically be desired by users to retain all other settings.