### PR TITLE
Lazy-load requests, simplepycons, and keyring

### DIFF
--- a/src/icon_downloader.py
+++ b/src/icon_downloader.py
@@ -2,9 +2,6 @@ import logging
 from pathlib import Path
 from urllib.parse import urljoin
 
-import requests
-from simplepycons import all_icons
-
 from src.constants import ENTE_CUSTOM_ICONS_URL, ENTE_ICONS_DATABASE_URL
 
 logger = logging.getLogger(__name__)
@@ -14,6 +11,7 @@ def search_ente_custom_icons(name: str) -> str | None:
     """
     Searches Ente custom icons on GitHub for the provided name and returns the SVG content if found.
     """
+    import requests
     try:
         response = requests.get(ENTE_ICONS_DATABASE_URL)
 
@@ -45,6 +43,7 @@ def search_ente_custom_icons(name: str) -> str | None:
 
 def search_simple_icons(name: str) -> str | None:
     """Searches Simple Icons for the provided name and returns the SVG content if found."""
+    from simplepycons import all_icons
     try:
         icon = all_icons[name]  # type: ignore
     except KeyError:

--- a/src/store_keychain.py
+++ b/src/store_keychain.py
@@ -2,7 +2,6 @@ import logging
 import os
 from pathlib import Path
 
-import keyring
 
 from src.constants import CACHE_ENV_VAR, KEYCHAIN_ACCOUNT, KEYCHAIN_SERVICE
 from src.models import ImportResult, TotpAccounts
@@ -22,6 +21,7 @@ def get_totp_accounts() -> TotpAccounts:
 
     # If not cached, load from the keychain
     logger.info("Loading TOTP accounts from keychain.")
+    import keyring
     accounts_json = keyring.get_password(
         service_name=KEYCHAIN_SERVICE, username=KEYCHAIN_ACCOUNT
     )
@@ -41,6 +41,7 @@ def ente_export_to_keychain(file: Path) -> ImportResult:
         accounts = parse_ente_export(file)
         accounts_json = accounts.to_json()
 
+        import keyring
         keyring.set_password(
             service_name=KEYCHAIN_SERVICE,
             username=KEYCHAIN_ACCOUNT,


### PR DESCRIPTION
Lazy load requests, simplepycons, and keyring to speed up search startup. Right now, typing in the search box has lag because these heavy modules are imported at startup. Moving them into functions makes search load way faster, since they are only imported when actually running the import subcommand.