### PR TITLE
Transient clipboard and secure import cleanup

### DIFF
--- a/main.py
+++ b/main.py
@@ -70,12 +70,14 @@ if __name__ == "__main__":
         ente_auth = EnteAuth()
 
         try:
-            ente_auth.export_ente_auth_accounts(ente_export_path, overwrite_export)
-            logger.info("Exported ente auth TOTP data to file.")
-        except Exception as e:
-            logger.exception(f"Failed to export ente auth TOTP data: {e}", e)
-            output_alfred_message("Failed to export TOTP data", str(e))
-        else:
+            try:
+                ente_auth.export_ente_auth_accounts(ente_export_path, overwrite_export)
+                logger.info("Exported ente auth TOTP data to file.")
+            except Exception as e:
+                logger.exception(f"Failed to export ente auth TOTP data: {e}", e)
+                output_alfred_message("Failed to export TOTP data", str(e))
+                sys.exit(1)
+
             try:
                 service_names_list: list[str] = []
                 result = ente_export_to_keychain(ente_export_path)
@@ -95,8 +97,9 @@ if __name__ == "__main__":
                 logger.exception(
                     f"Failed to populate TOTP data in keychain from file: {e}", e
                 )
-
-            ente_auth.delete_ente_export(ente_export_path)
+        finally:
+            if ente_export_path.exists():
+                ente_auth.delete_ente_export(ente_export_path)
 
     elif sys.argv[1] == "search":
         if len(sys.argv) < 3:

--- a/src/ente_auth.py
+++ b/src/ente_auth.py
@@ -34,8 +34,12 @@ class EnteAuth:
 
     def create_ente_export_dir(self, path: Path) -> None:
         if not path.exists():
-            os.makedirs(path)
-            logger.info(f"Ente folder created at: {path}")
+            os.makedirs(path, mode=0o700)
+        try:
+            os.chmod(path, 0o700)
+            logger.info(f"Ente folder created/secured at: {path}")
+        except Exception as e:
+            logger.warning(f"Could not secure export directory: {e}")
 
     def export_ente_auth_accounts(self, export_path: Path, overwrite: bool) -> None:
         """


### PR DESCRIPTION
Harden security: set transient clipboard copies in info.plist so 2FA codes aren't saved in clipboard history, force strict 0700 permissions on the export directory, and wrap the import process in a try-finally block to guarantee the plaintext secrets export file is deleted even if the script crashes.