### PR TITLE
Output comma-separated codes for next code modifier

### DIFF
--- a/src/totp_accounts_manager.py
+++ b/src/totp_accounts_manager.py
@@ -108,7 +108,7 @@ def format_totp_result(accounts: TotpAccounts) -> AlfredOutput:
                 AlfredOutputItem(
                     title=title,
                     subtitle=subtitle,
-                    arg=current_totp,
+                    arg=f"{current_totp},{next_totp}",
                     match=account.service_name,
                     icon=AlfredOutputItemIcon.from_service(sanitized_service_name),
                     uid=create_uuid_from_string(account.service_name + account.username),


### PR DESCRIPTION
Pass both the current and next TOTP codes comma-separated in the Alfred item arg instead of just the current code. This fixes the modifier option (when you hold option/alt) so you can copy/paste the next upcoming code.