### PR TITLE
Improve import usability and command-line compatibility

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -103,19 +103,7 @@
 				<false/>
 			</dict>
 		</array>
-		<key>E6427711-FED1-47CC-AA39-D59E50B504C7</key>
-		<array>
-			<dict>
-				<key>destinationuid</key>
-				<string>3101A957-02C3-4D0C-8B13-1C3721459261</string>
-				<key>modifiers</key>
-				<integer>0</integer>
-				<key>modifiersubtext</key>
-				<string></string>
-				<key>vitoclose</key>
-				<false/>
-			</dict>
-		</array>
+
 		<key>ECD812F2-4D1E-41CA-B344-81B25B4A6357</key>
 		<array>
 			<dict>
@@ -410,27 +398,7 @@ python3 main.py import</string>
 			<key>version</key>
 			<integer>3</integer>
 		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
-				<key>argumenttype</key>
-				<integer>2</integer>
-				<key>keyword</key>
-				<string>ente import</string>
-				<key>subtext</key>
-				<string></string>
-				<key>text</key>
-				<string>Import Ente Secrets</string>
-				<key>withspace</key>
-				<false/>
-			</dict>
-			<key>type</key>
-			<string>alfred.workflow.input.keyword</string>
-			<key>uid</key>
-			<string>E6427711-FED1-47CC-AA39-D59E50B504C7</string>
-			<key>version</key>
-			<integer>1</integer>
-		</dict>
+
 		<dict>
 			<key>config</key>
 			<dict>
@@ -560,13 +528,7 @@ ente version
 			<key>ypos</key>
 			<real>265.0</real>
 		</dict>
-		<key>E6427711-FED1-47CC-AA39-D59E50B504C7</key>
-		<dict>
-			<key>xpos</key>
-			<real>95.0</real>
-			<key>ypos</key>
-			<real>450.0</real>
-		</dict>
+
 		<key>ECD812F2-4D1E-41CA-B344-81B25B4A6357</key>
 		<dict>
 			<key>xpos</key>

--- a/main.py
+++ b/main.py
@@ -89,6 +89,7 @@ if __name__ == "__main__":
                 output_alfred_message(
                     "Imported TOTP data",
                     f"Successfully imported {result.count} TOTP accounts and downloaded icons.",
+                    variables={CACHE_ENV_VAR: result.accounts.to_json()},
                 )
             except Exception as e:
                 output_alfred_message("Failed to import TOTP data", str(e))

--- a/src/constants.py
+++ b/src/constants.py
@@ -8,7 +8,11 @@ KEYCHAIN_ACCOUNT = "totp_secrets"
 # Use an environment variable to cache the JSON data to reduce keychain calls
 CACHE_ENV_VAR = "TOTP_CACHE"
 
-ICONS_FOLDER = Path(environ["alfred_workflow_data"]) / "service_icons"
+workflow_data = environ.get("alfred_workflow_data")
+if workflow_data:
+    ICONS_FOLDER = Path(workflow_data) / "service_icons"
+else:
+    ICONS_FOLDER = Path("~/.cache/alfred-ente-auth").expanduser() / "service_icons"
 
 ENTE_ICONS_DATABASE_URL = "https://raw.githubusercontent.com/ente-io/ente/refs/heads/main/auth/assets/custom-icons/_data/custom-icons.json"
 ENTE_CUSTOM_ICONS_URL = "https://raw.githubusercontent.com/ente-io/ente/refs/heads/main/auth/assets/custom-icons/icons/"


### PR DESCRIPTION
Deletes the redundant keyword block in info.plist that was causing two identical "ente import" rows to show up in Alfred. It also updates Alfred's session cache (TOTP_CACHE) in main.py immediately on import, ensuring deleted accounts disappear instantly. Additionally, we fall back to a default cache folder (~/.cache/alfred-ente-auth) if alfred_workflow_data is missing, preventing Python from throwing KeyErrors when running direct command-line tests.